### PR TITLE
Run on Circle without private Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,18 +2,21 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester
+      - image: python:3.7-alpine
     steps:
       - checkout
       - run:
           name: 'Setup virtual env'
           command: |
-            /root/.pyenv/versions/3.6.9/bin/python -mvenv /usr/local/share/virtualenvs/tap-slack
-            source /usr/local/share/virtualenvs/tap-slack/bin/activate
+            mkdir -p ~/.virtualenvs
+            apk add build-base libffi-dev
+            pip install virtualenv
+            python -m virtualenv ~/.virtualenvs/tap-slack
+            source ~/.virtualenvs/tap-slack/bin/activate
             pip install -U 'pip<19.2' setuptools
             pip install .[dev]
       - run:
           name: 'pylint'
           command: |
-            source /usr/local/share/virtualenvs/tap-slack/bin/activate
+            source ~/.virtualenvs/tap-slack/bin/activate
             pylint tap_slack -d C,R,W,no-member


### PR DESCRIPTION
# Description of change
Currently the CircleCI config requires a private Docker image, so we can't use it from this fork.

This changes the build to an open source image.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
