### PR TITLE
Allow user to specify specific channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Create a config file containing the API token and a start date, e.g.:
 }
 ```
 
+### Private channels
+
 Optionally, you can also specify whether you want to sync private channels or not by adding the following to the config:
 
 ```json
@@ -40,6 +42,19 @@ Optionally, you can also specify whether you want to sync private channels or no
 By default, private channels will be synced, and therefore you will also need these additional scopes:
 - `groups:read`
 - `groups:history`
+
+### Specify channels to sync
+
+By default, the tap will sync all channels. However, you can limit the tap to sync only the channels you specify by adding their IDs to the config file, e.g.:
+
+```json
+"channels":[
+    "abc123",
+    "def345"
+  ]
+```
+
+Note this needs to be channel ID, not the name, as [recommended by the Slack API](https://api.slack.com/types/conversation#other_attributes). To get the ID for a channel, either use the Slack API or [find it in the URL](https://www.wikihow.com/Find-a-Channel-ID-on-Slack-on-PC-or-Mac).
 
 ## Usage
 

--- a/tap_slack/streams.py
+++ b/tap_slack/streams.py
@@ -31,7 +31,7 @@ class SlackStream():
     def write_state(self):
         return singer.write_state(self.state)
 
-    def channels(self):
+    def _all_channels(self):
         types = "public_channel"
         enable_private_channels = self.config.get("private_channels", True)
         if enable_private_channels:
@@ -42,6 +42,16 @@ class SlackStream():
             for channel in channels:
                 yield channel
 
+    def _specified_channels(self):
+        for channel_id in self.config.get("channels"):
+            page = self.webclient.conversations_info(channel=channel_id, include_num_members=0)
+            yield page.get('channel')
+
+    def channels(self):
+        if "channels" in self.config:
+            yield from self._specified_channels()
+        else:
+            yield from self._all_channels()
 
 class ConversationsStream(SlackStream):
     name = 'conversations'


### PR DESCRIPTION
# Description of change
This allows the user to optionally specify a limited set of channels to sync, rather than syncing them all (which remains the default).

# Manual QA steps
- Run without added `channels` config, and it should perform the same
- Add channels to the `channels` config, and only those will be synced
 
# Risks
 - No test coverage
 
# Rollback steps
 - revert this branch
